### PR TITLE
feat(SoundManager.ts): fix audio memory leak

### DIFF
--- a/src/cubism-common/SoundManager.ts
+++ b/src/cubism-common/SoundManager.ts
@@ -50,20 +50,17 @@ export class SoundManager {
         audio.preload = "auto";
         // audio.autoplay = true;
         audio.crossOrigin = crossOrigin!;
-        audioListenersWeakMap.set(
-            audio,
-            {
-                ended: () => {
-                    this.dispose(audio);
-                    onFinish?.();
-                },
-                error: (e: ErrorEvent) => {
-                    this.dispose(audio);
-                    logger.warn(TAG, `Error occurred on "${file}"`, e.error);
-                    onError?.(e.error);
-                }
-            }
-        )
+        audioListenersWeakMap.set(audio, {
+            ended: () => {
+                this.dispose(audio);
+                onFinish?.();
+            },
+            error: (e: ErrorEvent) => {
+                this.dispose(audio);
+                logger.warn(TAG, `Error occurred on "${file}"`, e.error);
+                onError?.(e.error);
+            },
+        });
         audio.addEventListener("ended", audioListenersWeakMap.get(audio).ended);
         audio.addEventListener("error", audioListenersWeakMap.get(audio).error);
 

--- a/src/cubism-common/SoundManager.ts
+++ b/src/cubism-common/SoundManager.ts
@@ -141,8 +141,8 @@ export class SoundManager {
      */
     static dispose(audio: HTMLAudioElement): void {
         audio.pause();
-        audio.removeEventListener("ended", audioListenersWeakMap.get(audio).ended);
-        audio.removeEventListener("error", audioListenersWeakMap.get(audio).error);
+        audio.removeEventListener("ended", audioListenersWeakMap.get(audio)?.ended);
+        audio.removeEventListener("error", audioListenersWeakMap.get(audio)?.error);
         audioListenersWeakMap.delete(audio);
         audio.removeAttribute("src");
 


### PR DESCRIPTION
When a program plays too many audio elements (e.g., 2000 instances), Chrome's garbage collector (GC) may fail to reclaim them, resulting in increased memory usage. My patch resolves this issue by improving GC efficiency.